### PR TITLE
Adding a CITATION.CFF

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,21 @@
+cff-version: 1.2.0
+message: If you use this plugin, please cite it using these metadata
+title: CZI-Citation-Final-draft
+authors:
+- family-names: "Sim\xE3o"
+  given-names: Bolota
+url: https://github.com/SimaoBolota-MetaCell/CZI-Citation-Final-draft
+date-released: '2022-01-01'
+references:
+- type: book
+  title: '{Instance segmentation of mitochondria in electron microscopy images with
+    a generalist deep learning model'
+  publisher: Cold Spring Harbor Laboratory
+  doi: 10.1101/2022.03.17.484806
+  url: https://www.biorxiv.org/content/early/2022/03/18/2022.03.17.484806
+- type: article
+  title: '{Instance segmentation of mitochondria in electron microscopy images with
+    a generalist deep learning model'
+  journal: bioRxiv
+  doi: 10.1101/2022.03.17.484806
+  url: https://www.biorxiv.org/content/early/2022/03/18/2022.03.17.484806


### PR DESCRIPTION

    Hello ,

    To help you adopt the recommended citation format for Napari plugins, we developed a tool that automatically generates a .CFF file containing the information about your plug in. This is how it works:
    - Our citation tool analyses and extracts information from your README.md file;
    - It prepares a draft of the CITATION.CFF and creates a pull request
    - All you have to do is to review the draft of the CITATION.CFF and edit it or approve it!
    - Accept the PR and merge it, your CITATION.CFF file will now meet the Napari plugin citation standards

    The .CFF is a plain text file with human- and machine-readable citation information for software and datasets. 

    Notes:
    The CITATION.CFF file naming needs to be as it is, otherwise it won’t be recognized.
    Some more information regarding .CFF can be found here https://citation-file-format.github.io/ 

    