### PR TITLE
Adding a CITATION.CFF

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,21 @@
+cff-version: 1.2.0
+message: If you use this plugin, please cite it using these metadata
+title: CZI-Citation-Final-draft
+authors:
+- family-names: simaosa
+  given-names: ''
+url: https://github.com/SimaoBolota-MetaCell/CZI-Citation-Final-draft
+date-released: '2022-01-01'
+references:
+- type: book
+  title: '{Instance segmentation of mitochondria in electron microscopy images with
+    a generalist deep learning model'
+  publisher: Cold Spring Harbor Laboratory
+  doi: 10.1101/2022.03.17.484806
+  url: https://www.biorxiv.org/content/early/2022/03/18/2022.03.17.484806
+- type: article
+  title: '{Instance segmentation of mitochondria in electron microscopy images with
+    a generalist deep learning model'
+  journal: bioRxiv
+  doi: 10.1101/2022.03.17.484806
+  url: https://www.biorxiv.org/content/early/2022/03/18/2022.03.17.484806

--- a/create_dict.py
+++ b/create_dict.py
@@ -4,7 +4,7 @@ import yaml
 NOT_AVAILABLE = ['Not Available']
 
 
-def add_to_dict(git_title, git_family_name, git_given_name, git_url,family_names, given_names, title, year, url, doi, publisher, journal):
+def add_to_dict(git_contributors, git_title, git_family_name, git_given_name, git_url,family_names, given_names, title, year, url, doi, publisher, journal):
 
     dict_file = {'cff-version': '1.2.0',
                  'message': 'If you use this plugin, please cite it using these metadata',
@@ -18,15 +18,25 @@ def add_to_dict(git_title, git_family_name, git_given_name, git_url,family_names
         else:
             dict_file[key] = value
 
-    
-    git_author_dict_file = {'authors': [
-                {'family-names': git_family_name, 'given-names': git_given_name}], }
+    if(git_contributors) and (len(git_contributors)>1):
+        for i in range(len(git_contributors)):
+            author_dict_file = {'authors': [
+                {'given-names': git_contributors[i]}], }
 
-    for key, value in git_author_dict_file.items():
+            for key, value in author_dict_file.items():
                 if key in dict_file:
                     dict_file[key].extend(value)
                 else:
                     dict_file[key] = value
+    else:
+        git_author_dict_file = {'authors': [
+                    {'family-names': git_family_name, 'given-names': git_given_name}], }
+
+        for key, value in git_author_dict_file.items():
+                    if key in dict_file:
+                        dict_file[key].extend(value)
+                    else:
+                        dict_file[key] = value
 
     git_url_dict_file = {'url':git_url  }
 

--- a/git_interaction.py
+++ b/git_interaction.py
@@ -1,0 +1,68 @@
+import git
+from githubInfo import *
+from pull_request import *
+
+
+
+
+def git_branch( repo_path, branch_name):
+
+    repo = git.Repo(repo_path)
+
+    origin = repo.remote("origin")
+
+    assert origin.exists()
+    origin.fetch()
+
+    
+
+
+    new_branch = repo.create_head(branch_name, origin.refs.main) 
+    new_branch.checkout()
+
+    
+
+
+
+def git_pull_request(repo_path,branch_name, git_token ):
+
+    repo = git.Repo(repo_path)
+
+    origin = repo.remote("origin")
+
+    assert origin.exists()
+    origin.fetch()
+
+    repo.index.add('CITATION.cff')
+    repo.index.commit("CFF Citation Added")
+    repo.git.push("--set-upstream", origin, repo.head.ref)
+
+    git_repo_name, git_author_family_name, git_author_given_name, git_repo_link, contributors_given_names = getGitInfo(repo_path)
+
+
+    pull_request_description = f"""
+    Hello {git_author_given_name},
+
+    To help you adopt the recommended citation format for Napari plugins, we developed a tool that automatically generates a .CFF file containing the information about your plug in. This is how it works:
+    - Our citation tool analyses and extracts information from your README.md file;
+    - It prepares a draft of the CITATION.CFF and creates a pull request
+    - All you have to do is to review the draft of the CITATION.CFF and edit it or approve it!
+    - Accept the PR and merge it, your CITATION.CFF file will now meet the Napari plugin citation standards
+
+    The .CFF is a plain text file with human- and machine-readable citation information for software and datasets. 
+
+    Notes:
+    The CITATION.CFF file naming needs to be as it is, otherwise it won’t be recognized.
+    Some more information regarding .CFF can be found here https://citation-file-format.github.io/ 
+
+    """
+
+    create_pull_request(
+        "SimaoBolota-MetaCell", # owner_name
+        git_repo_name, # repo_name
+        "Adding a CITATION.CFF", # title
+        pull_request_description, # description
+        branch_name, # head_branch
+        "main", # base_branch
+        git_token, # git_token
+    )

--- a/githubInfo.py
+++ b/githubInfo.py
@@ -1,0 +1,73 @@
+
+import git
+from patterns import *
+import re
+import requests
+
+def getGitInfo(repo_path):
+
+    repo = git.Repo(repo_path)
+
+    origin = repo.remote("origin")
+
+    assert origin.exists()
+    origin.fetch()
+
+    git_repo_name = repo.remotes.origin.url.split('.git')[0].split('/')[-1]
+
+
+
+    git_repo_link = repo.remotes.origin.url.split('.git')[0]
+    
+
+
+
+
+    git_author = repo.git.show("-s", "--format=Author: %an <%ae>")
+
+    git_author_family_name = re.findall(
+            GIT_FAMILY_NAMES_PATTERN, git_author, flags=re.DOTALL)
+
+
+
+    git_author_family_name = ''.join(map(str, git_author_family_name))
+
+    GIT_GIVEN_NAMES_PATTERN = '(?<=Author:\\s%s\\s)(.*?)(?=\\s)' % git_author_family_name
+
+    git_author_given_name = re.findall(
+            GIT_GIVEN_NAMES_PATTERN, git_author, flags=re.DOTALL)
+
+    git_author_given_name = ''.join(map(str, git_author_given_name))
+    
+    
+    all_contributors = list()
+    contributors_given_names = []
+    page_count = 1
+    while True:
+        contributors = requests.get("https://api.github.com/repos/SimaoBolota-MetaCell/CZI-Citation-Final-draft/contributors?page=%d"%page_count)
+        if contributors != None and contributors.status_code == 200 and len(contributors.json()) > 0:
+                all_contributors = all_contributors + contributors.json()
+        else:
+                break
+    page_count = page_count + 1
+    count=len(all_contributors)
+    if(count>0):
+        contributors_dict = all_contributors[0:(len(all_contributors))][0:(len(all_contributors))]
+        for single_contributor_dict in contributors_dict:
+                contributors_given_names.append(single_contributor_dict['login'])
+        # print(contributors_given_names)
+
+    return git_repo_name, git_author_family_name, git_author_given_name, git_repo_link, contributors_given_names
+
+
+
+
+git_repo_name, git_author_family_name, git_author_given_name, git_repo_link, contributors_given_names = getGitInfo('/Users/simaosa/Desktop/MetaCell/Projects/CZI/FinalCode_Citation_project/CZI-Citation-Final-draft')
+
+# print(git_repo_name)
+# print(git_author_family_name)
+# print(git_author_given_name)
+# print(git_repo_link)
+# print(contributors_given_names)
+
+

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from pull_request import *
 import yaml
 import git
 import json
+import requests
 import warnings
 from patterns import *
 import sys
@@ -13,70 +14,29 @@ from ruamel.yaml import *
 import tkinter
 from tkinter import *
 from tkinter import messagebox
+from githubInfo import *
+from git_interaction import *
 
 
+repo_path = '/Users/simaosa/Desktop/MetaCell/Projects/CZI/FinalCode_Citation_project/CZI-Citation-Final-draft'
+
+branch_name = 'branch_name3'
 
 
 ######################### GIT INTERACTIONS #########################
 
-import git
+git_repo_name, git_author_family_name, git_author_given_name, git_repo_link, contributors_given_names = getGitInfo(repo_path)
 
-repo = git.Repo('/Users/simaosa/Desktop/MetaCell/Projects/CZI/FinalCode_Citation_project/CZI-Citation-Final-draft')
-
-origin = repo.remote("origin")
-
-assert origin.exists()
-origin.fetch()
-
-git_repo_name = repo.remotes.origin.url.split('.git')[0].split('/')[-1]
-
-
-
-git_repo_link = repo.remotes.origin.url.split('.git')[0]
 git_readme_link = git_repo_link + '/blob/main/README.md'
-
-
 
 README_LINK = git_readme_link
 
-git_author = repo.git.show("-s", "--format=Author: %an <%ae>")
 
-git_author_family_name = re.findall(
-        GIT_FAMILY_NAMES_PATTERN, git_author, flags=re.DOTALL)
+######################### GIT BRANCH #########################
 
+git_branch( repo_path, branch_name)
 
-
-git_author_family_name = ''.join(map(str, git_author_family_name))
-
-GIT_GIVEN_NAMES_PATTERN = '(?<=Author:\\s%s\\s)(.*?)(?=\\s)' % git_author_family_name
-
-git_author_given_name = re.findall(
-        GIT_GIVEN_NAMES_PATTERN, git_author, flags=re.DOTALL)
-
-git_author_given_name = ''.join(map(str, git_author_given_name))
-
-
-
-# import json, requests
-# all_contributors = list()
-# contributors = requests.get("https://api.github.com/repos/SimaoBolota-MetaCell/CZI-Citation-Final-draft/contributors")
-# if contributors != None and contributors.status_code == 200 and len(contributors.json()) > 0:
-#         all_contributors = all_contributors + contributors.json()
-# print('\n')
-# print('HIII')
-# print(all_contributors)
-# print('\n')
-
-
-
-# git_token = input("Enter the authentication git token: ")
-
-
-# branch_name = '12september2022v2'
-# new_branch = repo.create_head(branch_name, origin.refs.main) 
-# new_branch.checkout()
-
-
+git_token = input("Enter the authentication git token: ")
 
 
 ######################### INITIALIZATIONS #########################
@@ -90,26 +50,19 @@ citation_year = {}
 citation_journal = {}
 citation_doi = {}
 
-isBibtex = bool(get_bibtex_citations(README_LINK))
-# isDOI = bool(get_citation_from_doi(README_LINK))
-
-
-
-
-
 # #########################  BIBTEX CITATION  ##########################
 
-if (isBibtex):
+if (bool(get_bibtex_citations(README_LINK))):
     print('BibTex Citation')
     all_bibtex_citations = get_bibtex_citations(README_LINK)
 
-    print(all_bibtex_citations)
     for individual_citation in all_bibtex_citations:
-
+        #data transformations needed to enasure the correct formatting outcome
         individual_citation = re.sub('"', '}', individual_citation)
         individual_citation = re.sub('= }', '= {', individual_citation)
         individual_citation = individual_citation + '}'
 
+        #collecting all citation fields from the BibTex READ.ME citation
         citation_family_names = get_bibtex_family_names(individual_citation)
         citation_given_names = get_bibtex_given_names(individual_citation)
         citation_title = get_bibtex_title(individual_citation)
@@ -120,7 +73,6 @@ if (isBibtex):
         citation_doi = get_bibtex_doi(individual_citation)
 
         # # print(individual_citation)
-        
         # print(citation_family_names)
         # print(citation_given_names)
         # print(citation_title)
@@ -131,11 +83,26 @@ if (isBibtex):
         # print(citation_doi)
 
 
-    filedict = add_to_dict(git_repo_name, git_author_family_name, git_author_given_name, git_repo_link,citation_family_names, citation_given_names, citation_title, citation_year, citation_url, citation_doi, citation_publisher, citation_journal )
+    #creating the dict that serves as a template for the CITATION.CFF
+    filedict = add_to_dict(
+            contributors_given_names,
+            git_repo_name, 
+            git_author_family_name, 
+            git_author_given_name, 
+            git_repo_link,
+            citation_family_names, 
+            citation_given_names, 
+            citation_title, 
+            citation_year, 
+            citation_url, 
+            citation_doi, 
+            citation_publisher, 
+            citation_journal )
 
     print('\n')
     print(filedict)
     print('\n')
+    #dump the dict contents into the final YAML file CITATION.CFF
     with open(r'./CZI-Citation-Final-draft/CITATION.cff', 'w') as file:
             documents = yaml.dump(filedict, file, sort_keys=False)
 
@@ -143,7 +110,7 @@ if (isBibtex):
 #########################  APA CITATION  ##########################
 
 
-elif isBibtex==False and bool(get_apa_citations(README_LINK)):
+elif bool(get_bibtex_citations(README_LINK))==False and bool(get_apa_citations(README_LINK)):
     
     
     APA_text, all_apa_authors, all_apa_citations = get_apa_citations(
@@ -165,7 +132,20 @@ elif isBibtex==False and bool(get_apa_citations(README_LINK)):
             citation_journal = get_apa_journal(citation_title, APA_text)
             citation_doi = get_apa_doi(APA_text)
 
-        filedict = add_to_dict(git_repo_name, git_author_family_name, git_author_given_name, git_repo_link,citation_family_names, citation_given_names, citation_title, citation_year, citation_url, citation_doi, citation_publisher, citation_journal )
+        filedict = add_to_dict(
+            contributors_given_names,
+            git_repo_name, 
+            git_author_family_name, 
+            git_author_given_name, 
+            git_repo_link,
+            citation_family_names, 
+            citation_given_names, 
+            citation_title, 
+            citation_year, 
+            citation_url, 
+            citation_doi, 
+            citation_publisher, 
+            citation_journal )
 
         print('\n')
         print(filedict)
@@ -205,7 +185,21 @@ elif isBibtex==False and bool(get_apa_citations(README_LINK)):
         print(citation_doi)
 
 
-        filedict = add_to_dict(git_repo_name, git_author_family_name, git_author_given_name, git_repo_link,citation_family_names, citation_given_names, citation_title, citation_year, citation_url, citation_doi, citation_publisher, citation_journal )
+        filedict = add_to_dict(
+            contributors_given_names,
+            git_repo_name, 
+            git_author_family_name, 
+            git_author_given_name, 
+            git_repo_link,
+            citation_family_names, 
+            citation_given_names, 
+            citation_title, 
+            citation_year, 
+            citation_url, 
+            citation_doi, 
+            citation_publisher, 
+            citation_journal )
+
 
         print('\n')
         print(filedict)
@@ -227,8 +221,21 @@ else:
     warnings.warn("Warning...........Please insert citation or DOI ")
 
 
-    filedict = add_to_dict(git_repo_name, git_author_family_name, git_author_given_name, git_repo_link,citation_family_names, citation_given_names, citation_title, citation_year, citation_url, citation_doi, citation_publisher, citation_journal )
-
+    filedict = add_to_dict(
+            contributors_given_names,
+            git_repo_name, 
+            git_author_family_name, 
+            git_author_given_name, 
+            git_repo_link,
+            citation_family_names, 
+            citation_given_names, 
+            citation_title, 
+            citation_year, 
+            citation_url, 
+            citation_doi, 
+            citation_publisher, 
+            citation_journal )
+    
     print('\n')
     print(filedict)
     print('\n')
@@ -238,59 +245,6 @@ else:
     
 
 
-
-
-import json, requests
-all_contributors = list()
-contributors_given_names = list()
-page_count = 1
-while True:
-    contributors = requests.get("https://api.github.com/repos/SimaoBolota-MetaCell/CZI-Citation-Final-draft/contributors?page=%d"%page_count)
-    if contributors != None and contributors.status_code == 200 and len(contributors.json()) > 0:
-        all_contributors = all_contributors + contributors.json()
-    else:
-        break
-    page_count = page_count + 1
-count=len(all_contributors)
-print("-------------------%d" %count)
-if(count>0):
-    contributors_dict = all_contributors[0:(len(all_contributors))][0:(len(all_contributors))]
-    for single_contributor_dict in contributors_dict:
-        print(type(single_contributor_dict))
-        contributors_given_names= contributors_given_names + ', '.join(single_contributor_dict['login'])
-    print(contributors_given_names)
-
-
 #########################  PUSH COMMITS and PULL REQUEST  ##########################
 
-
-# repo.index.add('CITATION.cff')
-# repo.index.commit("CFF Citation Added")
-# repo.git.push("--set-upstream", origin, repo.head.ref)
-
-# pull_request_description = f"""
-# Hello {git_author_name},
-
-# To help you adopt the recommended citation format for Napari plugins, we developed a tool that automatically generates a .CFF file containing the information about your plug in. This is how it works:
-# - Our citation tool analyses and extracts information from your README.md file;
-# - It prepares a draft of the CITATION.CFF and creates a pull request
-# - All you have to do is to review the draft of the CITATION.CFF and edit it or approve it!
-# - Accept the PR and merge it, your CITATION.CFF file will now meet the Napari plugin citation standards
-
-# The .CFF is a plain text file with human- and machine-readable citation information for software and datasets. 
-
-# Notes:
-# The CITATION.CFF file naming needs to be as it is, otherwise it won’t be recognized.
-# Some more information regarding .CFF can be found here https://citation-file-format.github.io/ 
-
-# """
-
-# create_pull_request(
-#     "SimaoBolota-MetaCell", # owner_name
-#     repo_name, # repo_name
-#     "Adding a CITATION.CFF", # title
-#     pull_request_description, # description
-#     branch_name, # head_branch
-#     "main", # base_branch
-#     git_token, # git_token
-# )
+git_pull_request(repo_path,branch_name, git_token )


### PR DESCRIPTION

    Hello ,

    To help you adopt the recommended citation format for Napari plugins, we developed a tool that automatically generates a .CFF file containing the information about your plug in. This is how it works:
    - Our citation tool analyses and extracts information from your README.md file;
    - It prepares a draft of the CITATION.CFF and creates a pull request
    - All you have to do is to review the draft of the CITATION.CFF and edit it or approve it!
    - Accept the PR and merge it, your CITATION.CFF file will now meet the Napari plugin citation standards

    The .CFF is a plain text file with human- and machine-readable citation information for software and datasets. 

    Notes:
    The CITATION.CFF file naming needs to be as it is, otherwise it won’t be recognized.
    Some more information regarding .CFF can be found here https://citation-file-format.github.io/ 

    