### PR TITLE
Adding a CITATION.CFF

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this plugin, please cite it using these metadata
 title: CZI-Citation-Final-draft
 authors:
-- family-names: Simao
+- family-names: Simaosdbgsfb
   given-names: sa
 url: https://github.com/SimaoBolota-MetaCell/CZI-Citation-Final-draft
 date-released: '2022-01-01'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this plugin, please cite it using these metadata
 title: CZI-Citation-Final-draft
 authors:
-- family-names: Simaosdbgsfb
+- family-names: Simaosdbgsfv d b
   given-names: sa
 url: https://github.com/SimaoBolota-MetaCell/CZI-Citation-Final-draft
 date-released: '2022-01-01'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this plugin, please cite it using these metadata
 title: CZI-Citation-Final-draft
 authors:
-- family-names: "Sim\xE3o"
-  given-names: "s\xE1"
+- family-names: Simao
+  given-names: sa
 url: https://github.com/SimaoBolota-MetaCell/CZI-Citation-Final-draft
 date-released: '2022-01-01'
 preferred-citation:


### PR DESCRIPTION

    Hello ,

    To help you adopt the recommended citation format for Napari plugins, we developed a tool that automatically generates a .CFF file containing the information about your plug in. This is how it works:
    - Our citation tool analyses and extracts information from your README.md file;
    - It prepares a draft of the CITATION.CFF and creates a pull request
    - All you have to do is to review the draft of the CITATION.CFF and edit it or approve it!
    - Accept the PR and merge it, your CITATION.CFF file will now meet the Napari plugin citation standards

    The .CFF is a plain text file with human- and machine-readable citation information for software and datasets. 

    Notes:
    The CITATION.CFF file naming needs to be as it is, otherwise it won’t be recognized.
    Some more information regarding .CFF can be found here https://citation-file-format.github.io/ 

    